### PR TITLE
Suggested solution

### DIFF
--- a/src/drivers/driver.py
+++ b/src/drivers/driver.py
@@ -141,8 +141,8 @@ class driver(threading.Thread):
 
                         # Action ADD VARIABLES
                         elif action == DriverActions.ADD_VARIABLES:
+                            self.raw_variables_def.update(data)
                             if self.status == DriverStatus.RUNNING: 
-                                self.raw_variables_def.update(data)
                                 if not self._addVariables(data):
                                     self.sendDebugInfo('ADD_VARIABLES action failed!')
 

--- a/src/drivers/twincat_ads/twincat_ads.py
+++ b/src/drivers/twincat_ads/twincat_ads.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from ..driver import driver, VariableQuality 
+from ..driver import VariableDatatype, driver, VariableQuality 
 
 from multiprocessing import Pipe
 from typing import Optional
@@ -99,7 +99,10 @@ class twincat_ads(driver):
             self.sendDebugInfo(f'readVariables exception: {e}')
         else:
             for var_id, value in values.items():
-                res.append((var_id, value, VariableQuality.GOOD))
+                if isinstance(value,str) and variables[var_id]['type'] != VariableDatatype.STRING:
+                    res.append((var_id, None, VariableQuality.BAD))
+                else:
+                    res.append((var_id, value, VariableQuality.GOOD))
 
         return res
 

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -30,7 +30,7 @@ from SimpleWebSocketServer import SimpleWebSocketServer, WebSocket
 
 
 # Version
-version = "4.0.1"
+version = "4.0.3"
 MAX_TELEGRAM_LENGTH = 2**13 # (8K)
 MAX_UPDATES_PER_TELEGRAM = 100
 


### PR DESCRIPTION
I think this simple mod allows all drivers to cleanly reconnect after some seconds.
Tested with OPCUA driver with good results.
It only required changing the behavior script to unblock the plc_state if the driver status is recovered:

OLD CODE:
![image](https://user-images.githubusercontent.com/36505430/189985850-624cd849-7867-4631-a71c-af39aa5377ba.png)

NEW CODE:
![image](https://user-images.githubusercontent.com/36505430/189985214-33cf0e29-57f5-473f-a576-34817ed7f6e8.png)
