### PR TITLE
include external axes to driver

### DIFF
--- a/src/drivers/kuka_varproxy/kuka_varproxy.py
+++ b/src/drivers/kuka_varproxy/kuka_varproxy.py
@@ -33,7 +33,7 @@ def axis_act_to_list(read_data):
     result = result.replace("}", "")
 
     data = result.split(',')
-    return [float(x[4:]) for x in data[:6]]
+    return [float(x[4:]) for x in data]
 
 def pack_read_request(var_id, msg_id):
     var_id_len = len(var_id)

--- a/src/tests/test_kuka_varproxy.py
+++ b/src/tests/test_kuka_varproxy.py
@@ -30,7 +30,7 @@ VARIABLES = {
     'In_BOOL':{'datatype': VariableDatatype.BOOL, 'size': 1, 'operation': VariableOperation.WRITE},
     'In_INTEGER':{'datatype': VariableDatatype.BYTE, 'size': 1, 'operation': VariableOperation.WRITE},
     'In_FLOAT':{'datatype': VariableDatatype.FLOAT, 'size': 1, 'operation': VariableOperation.WRITE},
-    '$AXIS_ACT': {'datatype': VariableDatatype.FLOAT, 'size': 6, 'operation': VariableOperation.READ},
+    '$AXIS_ACT': {'datatype': VariableDatatype.FLOAT, 'size': 12, 'operation': VariableOperation.READ},
     }
 
 # Add your custom logic in this test.


### PR DESCRIPTION
To be able to read the external axes in behavior of the robot controller, not only the six robot axes is read.